### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/amplify/backend/auth/mapsauthcontrols/mapsauthcontrols-cloudformation-template.yml
+++ b/amplify/backend/auth/mapsauthcontrols/mapsauthcontrols-cloudformation-template.yml
@@ -331,7 +331,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole

--- a/amplify/backend/auth/userPoolGroups/template.json
+++ b/amplify/backend/auth/userPoolGroups/template.json
@@ -342,7 +342,7 @@
                     }
                 },
                 "Handler": "index.handler",
-                "Runtime": "nodejs10.x",
+                "Runtime": "nodejs14.x",
                 "Timeout": "300",
                 "Role": {
                     "Fn::GetAtt": [

--- a/amplify/backend/function/mapsauthcontrolsPostConfirmation/mapsauthcontrolsPostConfirmation-cloudformation-template.json
+++ b/amplify/backend/function/mapsauthcontrolsPostConfirmation/mapsauthcontrolsPostConfirmation-cloudformation-template.json
@@ -104,7 +104,7 @@
               "Arn"
             ]
           },
-          "Runtime": "nodejs10.x",
+          "Runtime": "nodejs14.x",
           "Timeout": "25",
           "Code": {
             "S3Bucket": {


### PR DESCRIPTION
CloudFormation templates in aws-media-asset-preparation-system have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.